### PR TITLE
fix(remote): SSH commands fail when remote shell is fish

### DIFF
--- a/VibeHub/Services/Remote/RemoteActions.swift
+++ b/VibeHub/Services/Remote/RemoteActions.swift
@@ -78,10 +78,8 @@ for line in panes:
 sys.exit(1)
 """
 
-        let target = (await RemoteInstaller.runSSH(
-            host: host,
-            command: "python3 - \(pid) <<'PY'\n\(finder)\nPY"
-        ))?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let findResult = await RemoteInstaller.runSSHPython(host: host, script: finder, args: ["\(pid)"])
+        let target = findResult.exitCode == 0 ? findResult.output.trimmingCharacters(in: .whitespacesAndNewlines) : nil
 
         guard let target, !target.isEmpty else {
             await RemoteLog.shared.log(.info, "sendClaudeMessage: tmux target not found for pid=\(pid), will try TTY fallback")
@@ -124,8 +122,7 @@ except Exception as e:
 """
 
         let b64 = Data(text.utf8).base64EncodedString()
-        let cmd = "python3 - \(shellQuote(ttyPath)) \(b64) <<'PY'\n\(script)\nPY"
-        let r = await RemoteInstaller.runSSHResult(host: host, command: cmd, timeoutSeconds: 12)
+        let r = await RemoteInstaller.runSSHPython(host: host, script: script, args: [shellQuote(ttyPath), b64], timeoutSeconds: 12)
         if r.exitCode != 0 {
             await RemoteLog.shared.log(.warn, "sendClaudeMessage: TTY injection failed tty=\(ttyPath) exit=\(r.exitCode) stderr=\(r.stderr ?? "")")
             return (false, r.stderr?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmptyOrNil ?? "TTY injection failed")
@@ -173,8 +170,7 @@ s.close()
 
         // Encode prompt text as base64 argument to avoid stdin conflicts with heredoc.
         let b64 = Data(text.utf8).base64EncodedString()
-        let cmd = "python3 - \(pid) \(shellQuote(sid)) \(b64) <<'PY'\n\(payload)\nPY"
-        let r = await RemoteInstaller.runSSHResult(host: host, command: cmd, timeoutSeconds: 12)
+        let r = await RemoteInstaller.runSSHPython(host: host, script: payload, args: ["\(pid)", shellQuote(sid), b64], timeoutSeconds: 12)
         if r.exitCode != 0 {
             await RemoteLog.shared.log(.warn, "sendOpenCodePrompt ssh failed: exit=\(r.exitCode) stderr=\(r.stderr ?? "")", hostId: hostId)
             let hint = r.stderr?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmptyOrNil

--- a/VibeHub/Services/Remote/RemoteInstaller.swift
+++ b/VibeHub/Services/Remote/RemoteInstaller.swift
@@ -190,8 +190,8 @@ settings_path.write_text(json.dumps(data, indent=2, sort_keys=True))
 
         steps.append(await step(
             name: "update ~/.claude/settings.json",
-            command: "python3 - <<'PY' ... PY",
-            result: await runSSHResult(host: host, command: "python3 - <<'PY'\n\(py)\nPY", timeoutSeconds: 20)
+            command: "python3 (merge claude hook settings)",
+            result: await runSSHPython(host: host, script: py)
         ))
 
         return steps
@@ -294,8 +294,8 @@ print('ok')
 
         steps.append(await step(
             name: "update ~/.codex/hooks.json + config.toml",
-            command: "python3 - <<'PY' ... PY",
-            result: await runSSHResult(host: host, command: "python3 - <<'PY'\n\(py)\nPY", timeoutSeconds: 20)
+            command: "python3 (merge codex hook settings)",
+            result: await runSSHPython(host: host, script: py)
         ))
 
         return steps
@@ -495,6 +495,17 @@ print('ok')
             stdout: trim(result.output),
             stderr: trim(result.stderr ?? "")
         )
+    }
+
+    /// Run a Python script on the remote via SSH, encoding the script as base64 to avoid
+    /// shell-specific syntax (e.g. fish does not support heredocs).
+    static func runSSHPython(host: RemoteHost, script: String, args: [String] = [], timeoutSeconds: Int = 20) async -> ProcessResult {
+        let b64 = Data(script.utf8).base64EncodedString()
+        var cmd = "python3 -c \"import base64;exec(base64.b64decode('\(b64)'))\""
+        for arg in args {
+            cmd += " \(arg)"
+        }
+        return await runSSHResult(host: host, command: cmd, timeoutSeconds: timeoutSeconds)
     }
 
     private static func trim(_ s: String) -> String {

--- a/VibeHub/Services/Remote/RemoteManager.swift
+++ b/VibeHub/Services/Remote/RemoteManager.swift
@@ -511,8 +511,7 @@ s.close()
 print(\"sent\", token)
 """
 
-            let cmd = "python3 - '\(token)' <<'PY'\n\(py)\nPY"
-            let r = await RemoteInstaller.runSSHResult(host: host, command: cmd, timeoutSeconds: 10)
+            let r = await RemoteInstaller.runSSHPython(host: host, script: py, args: ["'\(token)'"], timeoutSeconds: 10)
             if r.exitCode != 0 {
                 await RemoteLog.shared.log(.warn, "healthcheck ssh failed exit=\(r.exitCode) stderr=\(r.stderr ?? "")", hostId: id)
                 if r.exitCode == 255 {


### PR DESCRIPTION
## Summary
- Replaces bash-style heredocs (`<<'PY'`) with base64-encoded `python3 -c` invocations for all remote Python script execution
- Adds `runSSHPython(host:script:args:timeoutSeconds:)` helper to `RemoteInstaller`, alongside the existing `runSSH`/`runSSHResult`
- Works with any remote login shell (bash, zsh, fish, etc.)

## Problem
Fish shell doesn't support heredoc syntax. Remote connections to hosts with fish as the login shell fail with:
```
fish: Expected string, but found a redirection
python3 - <<
```

## Test plan
- [x] Builds successfully
- [x] Tested locally (app launches and runs)
- [x] Verified remote connection to a fish-shell host works

Closes #8